### PR TITLE
feat: add local asset dashboard with annualized return

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,795 +1,735 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-TW">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
-  <title>個人資產儀表板</title>
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;700&display=swap" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.22.9/babel.min.js"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <style>
-    body {
-      font-family: 'Noto Sans TC', sans-serif;
-      background-color: #E0F0EA;
-    }
-    .miyazaki-card {
-      background-color: #FFF8E7;
-      border-radius: 12px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
-    .miyazaki-button {
-      background-color: #2F4F4F;
-      color: #FFF8E7;
-      padding: 0.5rem 1rem;
-    }
-    .miyazaki-button:hover {
-      background-color: #4682B4;
-    }
-    .miyazaki-header {
-      background-color: #2F4F4F;
-      color: #FFF8E7;
-    }
-    .miyazaki-table-header {
-      background-color: #E0F0EA;
-    }
-    .delete-button {
-      background-color: #FF6F61;
-      color: white;
-      padding: 0.25rem 0.5rem;
-      border-radius: 4px;
-    }
-    .delete-button:hover {
-      background-color: #EF4444;
-    }
-    .edit-button {
-      background-color: #6B8E23;
-      color: white;
-      padding: 0.25rem 0.5rem;
-      border-radius: 4px;
-      margin-right: 0.5rem;
-    }
-    .edit-button:hover {
-      background-color: #556B2F;
-    }
-    .export-button {
-      background-color: #FFD700;
-      color: #2F4F4F;
-      padding: 0.5rem 1rem;
-      border-radius: 4px;
-      margin-top: 1rem;
-    }
-    .export-button:hover {
-      background-color: #FFC107;
-    }
-    .toggle-button {
-      cursor: pointer;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-    .asset-name {
-      font-size: 1.25rem;
-      font-weight: bold;
-    }
-    .asset-detail {
-      color: #4682B4;
-      font-size: 1rem;
-    }
-    .asset-info {
-      padding-left: 1rem;
-      border-left: 4px solid #2F4F4F;
-    }
-    /* 手機端優化 */
-    @media (max-width: 640px) {
-      h1 {
-        font-size: 1.5rem;
-      }
-      h2 {
-        font-size: 1.25rem;
-      }
-      h3 {
-        font-size: 1rem;
-      }
-      p, li, input, select, button, th, td {
-        font-size: 0.875rem;
-      }
-      input, select, button {
-        padding: 0.5rem;
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes"
+    />
+    <title>個人資產儀表板</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.22.9/babel.min.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      body {
+        font-family: "Noto Sans TC", sans-serif;
+        background-color: #e0f0ea;
       }
       .miyazaki-card {
-        padding: 1rem;
+        background-color: #fff8e7;
+        border-radius: 12px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
       }
-      table {
-        font-size: 0.75rem;
+      .miyazaki-button {
+        background-color: #2f4f4f;
+        color: #fff8e7;
+        padding: 0.5rem 1rem;
       }
-      th, td {
-        padding: 0.25rem;
+      .miyazaki-button:hover {
+        background-color: #4682b4;
       }
-      canvas {
-        max-height: 200px;
+      .miyazaki-header {
+        background-color: #2f4f4f;
+        color: #fff8e7;
       }
-      .asset-info {
-        font-size: 0.75rem;
+      .miyazaki-table-header {
+        background-color: #e0f0ea;
+      }
+      .delete-button {
+        background-color: #ff6f61;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+      }
+      .delete-button:hover {
+        background-color: #ef4444;
+      }
+      .edit-button {
+        background-color: #6b8e23;
+        color: white;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        margin-right: 0.5rem;
+      }
+      .edit-button:hover {
+        background-color: #556b2f;
+      }
+      .export-button {
+        background-color: #ffd700;
+        color: #2f4f4f;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        margin-top: 1rem;
+      }
+      .export-button:hover {
+        background-color: #ffc107;
+      }
+      .toggle-button {
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
       }
       .asset-name {
-        font-size: 1rem;
+        font-size: 1.25rem;
+        font-weight: bold;
       }
       .asset-detail {
-        font-size: 0.875rem;
+        color: #4682b4;
+        font-size: 1rem;
       }
-    }
-  </style>
-</head>
-<body>
-  <div id="root"></div>
-  <script type="text/babel">
-    const { useState, useEffect } = React;
+      .asset-info {
+        padding-left: 1rem;
+        border-left: 4px solid #2f4f4f;
+      }
+      /* 手機端優化 */
+      @media (max-width: 640px) {
+        h1 {
+          font-size: 1.5rem;
+        }
+        h2 {
+          font-size: 1.25rem;
+        }
+        h3 {
+          font-size: 1rem;
+        }
+        p,
+        li,
+        input,
+        select,
+        button,
+        th,
+        td {
+          font-size: 0.875rem;
+        }
+        input,
+        select,
+        button {
+          padding: 0.5rem;
+        }
+        .miyazaki-card {
+          padding: 1rem;
+        }
+        table {
+          font-size: 0.75rem;
+        }
+        th,
+        td {
+          padding: 0.25rem;
+        }
+        canvas {
+          max-height: 200px;
+        }
+        .asset-info {
+          font-size: 0.75rem;
+        }
+        .asset-name {
+          font-size: 1rem;
+        }
+        .asset-detail {
+          font-size: 0.875rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const { useState, useEffect, useRef } = React;
 
-    const initialAssets = [];
+      const initialAssets = [];
 
-    const AssetDashboard = () => {
-      const [assets, setAssets] = useState(() => {
-        const saved = localStorage.getItem('assets');
-        return saved ? JSON.parse(saved) : initialAssets;
-      });
-      const [newTransaction, setNewTransaction] = useState({
-        name: '',
-        type: 'ETF',
-        transactionType: '買進',
-        date: '2025-08-08',
-        unitPrice: '',
-        shares: '1000',
-        fee: 0,
-        amount: 0
-      });
-      const [selectedAsset, setSelectedAsset] = useState(null);
-      const [showRecords, setShowRecords] = useState(false);
-      const [editingRecord, setEditingRecord] = useState(null);
-      const [expandedAssets, setExpandedAssets] = useState({});
-      const [showTransactionForm, setShowTransactionForm] = useState(false);
-      const [realTimePrices, setRealTimePrices] = useState({});
-      const [showPieChart, setShowPieChart] = useState(false); // 控制圓餅圖收合
+      const AssetDashboard = () => {
+        const [assets, setAssets] = useState(() => {
+          const saved = localStorage.getItem("assets");
+          return saved ? JSON.parse(saved) : initialAssets;
+        });
+        const [newTransaction, setNewTransaction] = useState({
+          name: "",
+          type: "ETF",
+          transactionType: "買進",
+          date: "2025-08-08",
+          unitPrice: "",
+          shares: "",
+          fee: 0,
+          amount: 0,
+        });
+        const [selectedAsset, setSelectedAsset] = useState(null);
+        const [showRecords, setShowRecords] = useState(false);
+        const [editingRecord, setEditingRecord] = useState(null);
+        const [expandedAssets, setExpandedAssets] = useState({});
+        const [showTransactionForm, setShowTransactionForm] = useState(false);
+        const [showPieChart, setShowPieChart] = useState(false); // 控制圓餅圖收合
 
-      // Alpha Vantage API金鑰
-      const API_KEY = 'QI5UH4EWKQITDK0K';
+        // 儲存到localStorage
+        useEffect(() => {
+          localStorage.setItem("assets", JSON.stringify(assets));
+        }, [assets]);
 
-      // 獲取即時股價
-      useEffect(() => {
-        const fetchPrices = async () => {
-          const prices = {};
-          for (const asset of assets) {
-            if (asset.type !== '現金') {
-              try {
-                const response = await fetch(
-                  `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${asset.name}.TWO&apikey=${API_KEY}`
-                );
-                const data = await response.json();
-                if (data['Global Quote'] && data['Global Quote']['05. price']) {
-                  prices[asset.name] = parseFloat(data['Global Quote']['05. price']);
-                } else {
-                  prices[asset.name] = 0;
-                }
-              } catch (error) {
-                console.error(`獲取${asset.name}股價失敗:`, error);
-                prices[asset.name] = 0;
-              }
-            } else {
-              prices[asset.name] = 1; // 現金1:1
+        const totalValue = assets.reduce(
+          (sum, asset) => sum + calculateHoldingCost(asset.history),
+          0,
+        );
+
+        const overallAnnualizedReturn = () => {
+          let totalDividend = 0;
+          let first = null;
+          assets.forEach((asset) => {
+            if (asset.history.length > 0) {
+              totalDividend += calculateTotalDividend(asset.history);
+              const fd = asset.history[0].date;
+              if (!first || new Date(fd) < new Date(first)) first = fd;
             }
-          }
-          setRealTimePrices(prices);
+          });
+          if (totalValue <= 0 || !first) return "N/A";
+          const years =
+            (new Date("2025-08-08") - new Date(first)) /
+            (365 * 24 * 60 * 60 * 1000);
+          if (years <= 0) return "N/A";
+          const annual =
+            (Math.pow((totalValue + totalDividend) / totalValue, 1 / years) -
+              1) *
+            100;
+          return annual.toFixed(2);
         };
 
-        if (assets.length > 0) {
-          fetchPrices();
-        }
-      }, [assets]);
-
-      // 儲存到localStorage
-      useEffect(() => {
-        localStorage.setItem('assets', JSON.stringify(assets));
-      }, [assets]);
-
-      const totalValue = assets.reduce((sum, asset) => sum + asset.value, 0);
-
-      // 模擬金管會正式名稱
-      const getFormalName = (name) => {
-        const formalNames = {
-          '00878': '國泰永續高股息ETF',
-          '00929': '復華台灣科技優息ETF'
+        // 計算買進價格（含息和不含息）
+        const calculateBuyPrice = (history) => {
+          const cost = calculateHoldingCost(history);
+          const dividend = calculateTotalDividend(history);
+          return {
+            withDividend: Math.round(cost + dividend),
+            withoutDividend: Math.round(cost),
+          };
         };
-        return formalNames[name] || name;
-      };
 
-      // 計算買進價格（含息和不含息）
-      const calculateBuyPrice = (history) => {
-        let totalBuyPrice = 0;
-        let totalDividend = 0;
-        history.forEach(record => {
-          if (record.type === '買進') {
-            totalBuyPrice += record.unitPrice * record.shares + record.fee;
-          } else if (record.type === '除息') {
-            totalDividend += record.unitPrice * record.shares;
-          }
-        });
-        return { withDividend: Math.round(totalBuyPrice + totalDividend), withoutDividend: Math.round(totalBuyPrice) };
-      };
-
-      // 計算持有股數（截至指定日期）
-      const calculateHeldShares = (history, date, excludeCurrentDay = false) => {
-        const comparator = excludeCurrentDay ? (recordDate, targetDate) => new Date(recordDate) < targetDate : (recordDate, targetDate) => new Date(recordDate) <= targetDate;
-        return history
-          .filter(record => comparator(record.date, new Date(date)))
-          .reduce((total, record) => {
-            if (record.type === '買進') return total + record.shares;
-            if (record.type === '賣出') return total - record.shares;
-            return total;
-          }, 0);
-      };
-
-      // 計算每股買進均價
-      const calculateAverageBuyPrice = (history) => {
-        let totalBuyCost = 0;
-        let totalDividend = 0;
-        let totalShares = calculateHeldShares(history, '2025-08-08');
-        history.forEach(record => {
-          if (record.type === '買進') {
-            totalBuyCost += record.unitPrice * record.shares + record.fee;
-          } else if (record.type === '除息') {
-            totalDividend += record.unitPrice * record.shares;
-          }
-        });
-        if (totalShares === 0) return { withDividend: 'N/A', withoutDividend: 'N/A' };
-        return {
-          withDividend: ((totalBuyCost + totalDividend) / totalShares).toFixed(2),
-          withoutDividend: (totalBuyCost / totalShares).toFixed(2)
+        // 計算持有股數（截至指定日期）
+        const calculateHeldShares = (
+          history,
+          date,
+          excludeCurrentDay = false,
+        ) => {
+          const comparator = excludeCurrentDay
+            ? (recordDate, targetDate) => new Date(recordDate) < targetDate
+            : (recordDate, targetDate) => new Date(recordDate) <= targetDate;
+          return history
+            .filter((record) => comparator(record.date, new Date(date)))
+            .reduce((total, record) => {
+              if (record.type === "買進" || record.type === "存入")
+                return total + record.shares;
+              if (record.type === "賣出" || record.type === "提取")
+                return total - record.shares;
+              return total;
+            }, 0);
         };
-      };
 
-      // 計算累計配息
-      const calculateTotalDividend = (history) => {
-        return Math.round(history
-          .filter(record => record.type === '除息')
-          .reduce((sum, record) => sum + record.unitPrice * record.shares, 0));
-      };
+        // 計算每股買進均價
+        const calculateAverageBuyPrice = (history) => {
+          const totalShares = calculateHeldShares(history, "2025-08-08");
+          if (totalShares === 0)
+            return { withDividend: "N/A", withoutDividend: "N/A" };
+          const cost = calculateHoldingCost(history);
+          const dividend = calculateTotalDividend(history);
+          return {
+            withDividend: ((cost + dividend) / totalShares).toFixed(2),
+            withoutDividend: (cost / totalShares).toFixed(2),
+          };
+        };
 
-      // 計算張數
-      const calculateLots = (history) => {
-        const shares = calculateHeldShares(history, '2025-08-08');
-        return Math.round(shares / 1000);
-      };
+        // 計算累計配息
+        const calculateTotalDividend = (history) => {
+          return Math.round(
+            history
+              .filter((record) => record.type === "除息")
+              .reduce(
+                (sum, record) => sum + record.unitPrice * record.shares,
+                0,
+              ),
+          );
+        };
 
-      // 計算目前市值
-      const calculateCurrentMarketValue = (history, name) => {
-        const shares = calculateHeldShares(history, '2025-08-08');
-        const price = realTimePrices[name] || 0;
-        return Math.round(shares * price);
-      };
+        // 計算持有成本
+        const calculateHoldingCost = (history) => {
+          return Math.round(
+            history
+              .filter((record) => record.type !== "除息")
+              .reduce((sum, record) => sum + record.amount, 0),
+          );
+        };
 
-      // 計算持有成本
-      const calculateHoldingCost = (history) => {
-        let totalCost = 0;
-        history.forEach(record => {
-          if (record.type.includes('買進') || record.type.includes('存入') || record.type === '除息') {
-            totalCost += record.unitPrice * record.shares + record.fee;
-          } else if (record.type.includes('賣出') || record.type.includes('提取')) {
-            totalCost -= (record.unitPrice * record.shares - record.fee);
+        // 計算年化報酬率
+        const calculateAnnualizedReturn = (history) => {
+          const cost = calculateHoldingCost(history);
+          const shares = calculateHeldShares(history, "2025-08-08");
+          const dividend = calculateTotalDividend(history);
+          if (cost <= 0 || shares <= 0) return "N/A";
+          const firstDate = history.length ? history[0].date : null;
+          if (!firstDate) return "N/A";
+          const years =
+            (new Date("2025-08-08") - new Date(firstDate)) /
+            (365 * 24 * 60 * 60 * 1000);
+          if (years <= 0) return "N/A";
+          const annual =
+            (Math.pow((cost + dividend) / cost, 1 / years) - 1) * 100;
+          return annual.toFixed(2);
+        };
+
+        // 按日期排序交易紀錄
+        const sortHistoryByDate = (history) => {
+          return [...history].sort(
+            (a, b) => new Date(a.date) - new Date(b.date),
+          );
+        };
+
+        // 展開/收合資產詳細資訊
+        const toggleAssetDetails = (assetId) => {
+          setExpandedAssets((prev) => ({
+            ...prev,
+            [assetId]: !prev[assetId],
+          }));
+        };
+
+        // 展開/收合新增交易表單
+        const toggleTransactionForm = () => {
+          setShowTransactionForm((prev) => !prev);
+        };
+
+        // 展開/收合圓餅圖
+        const togglePieChart = () => {
+          setShowPieChart((prev) => !prev);
+        };
+
+        useEffect(() => {
+          const ctx = document.getElementById("assetChart")?.getContext("2d");
+          if (!ctx || !showPieChart) return;
+          if (chartRef.current) chartRef.current.destroy();
+          chartRef.current = new Chart(ctx, {
+            type: "pie",
+            data: {
+              labels: assets.map((asset) => asset.name),
+              datasets: [
+                {
+                  data: assets.map((asset) =>
+                    calculateHoldingCost(asset.history),
+                  ),
+                  backgroundColor: ["#4682B4", "#6B8E23", "#FFD700", "#FF6F61"],
+                },
+              ],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { position: "right", labels: { font: { size: 12 } } },
+              },
+            },
+          });
+        }, [assets, showPieChart]);
+
+        const calculateFeeAndAmount = (
+          unitPrice,
+          shares,
+          transactionType,
+          assetType,
+          fee,
+        ) => {
+          const value = unitPrice * shares;
+          const calculatedFee =
+            transactionType === "除息"
+              ? 10
+              : assetType !== "現金"
+                ? Math.ceil(value * 0.001425)
+                : 0;
+          const effectiveFee = fee !== undefined ? fee : calculatedFee;
+          let amount = value + effectiveFee;
+          if (
+            transactionType.includes("賣出") ||
+            transactionType.includes("提取")
+          ) {
+            amount = -(value - effectiveFee);
+          } else if (transactionType === "除息") {
+            amount = value;
           }
-        });
-        return Math.round(totalCost);
-      };
+          return { fee: effectiveFee, amount };
+        };
 
-      // 按日期排序交易紀錄
-      const sortHistoryByDate = (history) => {
-        return [...history].sort((a, b) => new Date(a.date) - new Date(b.date));
-      };
-
-      // 展開/收合資產詳細資訊
-      const toggleAssetDetails = (assetId) => {
-        setExpandedAssets(prev => ({
-          ...prev,
-          [assetId]: !prev[assetId]
-        }));
-      };
-
-      // 展開/收合新增交易表單
-      const toggleTransactionForm = () => {
-        setShowTransactionForm(prev => !prev);
-      };
-
-      // 展開/收合圓餅圖
-      const togglePieChart = () => {
-        setShowPieChart(prev => !prev);
-      };
-
-      useEffect(() => {
-        const ctx = document.getElementById('assetChart')?.getContext('2d');
-        if (!ctx || !showPieChart) return;
-        const chart = new Chart(ctx, {
-          type: 'pie', // 改為圓餅圖
-          data: {
-            labels: assets.map(asset => asset.name),
-            datasets: [{
-              data: assets.map(asset => calculateCurrentMarketValue(asset.history, asset.name)),
-              backgroundColor: ['#4682B4', '#6B8E23', '#FFD700', '#FF6F61'],
-            }],
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: { legend: { position: 'right', labels: { font: { size: 12 } } } },
-          },
-        });
-        return () => chart.destroy();
-      }, [assets, realTimePrices, showPieChart]);
-
-      const calculateFeeAndAmount = (unitPrice, shares, transactionType, assetType, fee) => {
-        const value = unitPrice * shares;
-        const calculatedFee = transactionType === '除息' ? 10 : (assetType !== '現金' ? Math.ceil(value * 0.001425) : 0);
-        const effectiveFee = fee !== undefined ? fee : calculatedFee;
-        let amount = value + effectiveFee;
-        if (transactionType.includes('賣出') || transactionType.includes('提取')) {
-          amount = -(value - effectiveFee);
-        } else if (transactionType === '除息') {
-          amount = value;
-        }
-        return { fee: calculatedFee, amount };
-      };
-
-      const handleInputChange = (e) => {
-        const { name, value } = e.target;
-        setNewTransaction(prev => {
-          const updated = { ...prev, [name]: value };
-          if (name === 'name' || name === 'date' || name === 'type' || name === 'transactionType') {
-            if (updated.transactionType === '除息') {
-              const asset = assets.find(a => a.name === updated.name);
-              updated.shares = asset ? calculateHeldShares(asset.history, updated.date, true).toString() : '0';
+        const handleInputChange = (e) => {
+          const { name, value } = e.target;
+          setNewTransaction((prev) => {
+            const updated = { ...prev, [name]: value };
+            if (
+              name === "name" ||
+              name === "date" ||
+              name === "type" ||
+              name === "transactionType"
+            ) {
+              if (updated.transactionType === "除息") {
+                const asset = assets.find((a) => a.name === updated.name);
+                updated.shares = asset
+                  ? calculateHeldShares(
+                      asset.history,
+                      updated.date,
+                      true,
+                    ).toString()
+                  : "0";
+                updated.fee = 10;
+              }
+            }
+            if (
+              name === "unitPrice" ||
+              name === "shares" ||
+              name === "transactionType" ||
+              name === "fee"
+            ) {
+              const unitPriceVal = parseFloat(updated.unitPrice || 0);
+              const sharesVal = parseInt(updated.shares || 0);
+              const feeVal = parseInt(updated.fee || 0);
+              const { fee: calcFee, amount } = calculateFeeAndAmount(
+                unitPriceVal,
+                sharesVal,
+                updated.transactionType,
+                updated.type,
+                name === "fee" ? feeVal : undefined,
+              );
+              updated.fee = name !== "fee" ? calcFee : feeVal;
+              updated.amount = amount;
+            }
+            if (name === "type") {
+              updated.transactionType =
+                updated.type === "現金" ? "存入" : "買進";
+              updated.shares = updated.type === "現金" ? "1" : "";
+              updated.fee = updated.type === "現金" ? 0 : prev.fee;
+            }
+            if (name === "transactionType" && value === "除息") {
+              const asset = assets.find((a) => a.name === updated.name);
+              updated.shares = asset
+                ? calculateHeldShares(
+                    asset.history,
+                    updated.date,
+                    true,
+                  ).toString()
+                : "0";
               updated.fee = 10;
             }
-          }
-          if (name === 'unitPrice' || name === 'shares' || name === 'transactionType' || name === 'fee') {
-            const unitPriceVal = parseFloat(updated.unitPrice || 0);
-            const sharesVal = parseInt(updated.shares || 0);
-            const feeVal = parseInt(updated.fee || 0);
-            const { fee: calcFee, amount } = calculateFeeAndAmount(
-              unitPriceVal,
-              sharesVal,
-              updated.transactionType,
-              updated.type,
-              name === 'fee' ? feeVal : undefined
-            );
-            updated.fee = name !== 'fee' ? calcFee : feeVal;
-            updated.amount = amount;
-          }
-          if (name === 'type') {
-            updated.transactionType = updated.type === '現金' ? '存入' : '買進';
-            updated.shares = updated.type === '現金' ? '1' : '1000';
-            updated.fee = updated.type === '現金' ? 0 : prev.fee;
-          }
-          if (name === 'transactionType' && value === '除息') {
-            const asset = assets.find(a => a.name === updated.name);
-            updated.shares = asset ? calculateHeldShares(asset.history, updated.date, true).toString() : '0';
-            updated.fee = 10;
-          }
-          return updated;
-        });
-      };
-
-      const handleAddTransaction = () => {
-        if (!newTransaction.name || !newTransaction.unitPrice || !newTransaction.shares) return;
-
-        const unitPrice = parseFloat(newTransaction.unitPrice);
-        const shares = parseInt(newTransaction.shares);
-        const fee = parseInt(newTransaction.fee);
-        const { amount } = calculateFeeAndAmount(unitPrice, shares, newTransaction.transactionType, newTransaction.type, fee);
-        const transaction = {
-          date: newTransaction.date,
-          type: newTransaction.transactionType,
-          unitPrice,
-          shares,
-          fee,
-          amount
-        };
-
-        let updatedAssets = [...assets];
-        let assetIndex = updatedAssets.findIndex(a => a.name === newTransaction.name);
-
-        if (assetIndex === -1) {
-          updatedAssets.push({
-            id: assets.length + 1,
-            name: newTransaction.name,
-            type: newTransaction.type,
-            value: (newTransaction.transactionType.includes('買進') || newTransaction.transactionType.includes('存入') || newTransaction.transactionType === '除息') ? (unitPrice * shares + fee) : 0,
-            history: [transaction]
+            return updated;
           });
-        } else {
-          const deltaValue = (newTransaction.transactionType.includes('賣出') || newTransaction.transactionType.includes('提取')) ? -(unitPrice * shares - fee) : (unitPrice * shares + fee);
-          updatedAssets[assetIndex].value += deltaValue;
-          updatedAssets[assetIndex].history.push(transaction);
-          updatedAssets[assetIndex].history = sortHistoryByDate(updatedAssets[assetIndex].history);
-        }
-
-        setAssets(updatedAssets);
-        setNewTransaction({
-          name: '',
-          type: 'ETF',
-          transactionType: '買進',
-          date: '2025-08-08',
-          unitPrice: '',
-          shares: '1000',
-          fee: 0,
-          amount: 0
-        });
-      };
-
-      const deleteRecord = (index) => {
-        const updatedHistory = [...selectedAsset.history];
-        const record = updatedHistory[index];
-        const deltaValue = (record.type.includes('賣出') || record.type.includes('提取')) ? -(record.unitPrice * record.shares - record.fee) : (record.unitPrice * record.shares + record.fee);
-        const updatedValue = selectedAsset.value - deltaValue;
-        updatedHistory.splice(index, 1);
-        const updatedAssets = assets.map(a => a.id === selectedAsset.id ? {...a, history: sortHistoryByDate(updatedHistory), value: updatedValue} : a);
-        setAssets(updatedAssets);
-        setSelectedAsset({...selectedAsset, history: sortHistoryByDate(updatedHistory), value: updatedValue});
-      };
-
-      const startEditingRecord = (index) => {
-        const record = selectedAsset.history[index];
-        setEditingRecord({ index, ...record });
-      };
-
-      const handleEditChange = (e) => {
-        const { name, value } = e.target;
-        setEditingRecord(prev => {
-          const updated = { ...prev, [name]: value };
-          if (name === 'unitPrice' || name === 'shares' || name === 'fee') {
-            const unitPriceVal = parseFloat(updated.unitPrice || 0);
-            const sharesVal = parseInt(updated.shares || 0);
-            const feeVal = parseInt(updated.fee || 0);
-            const { amount } = calculateFeeAndAmount(
-              unitPriceVal,
-              sharesVal,
-              updated.type,
-              selectedAsset.type,
-              feeVal
-            );
-            updated.amount = amount;
-          }
-          return updated;
-        });
-      };
-
-      const saveEditRecord = () => {
-        if (!editingRecord.date || !editingRecord.unitPrice || !editingRecord.shares) return;
-
-        const unitPrice = parseFloat(editingRecord.unitPrice);
-        const shares = parseInt(editingRecord.shares);
-        const fee = parseInt(editingRecord.fee);
-        const { amount } = calculateFeeAndAmount(unitPrice, shares, editingRecord.type, selectedAsset.type, fee);
-
-        const oldRecord = selectedAsset.history[editingRecord.index];
-        const oldDeltaValue = (oldRecord.type.includes('賣出') || oldRecord.type.includes('提取')) ? -(oldRecord.unitPrice * oldRecord.shares - oldRecord.fee) : (oldRecord.unitPrice * oldRecord.shares + oldRecord.fee);
-        const newDeltaValue = (editingRecord.type.includes('賣出') || editingRecord.type.includes('提取')) ? -(unitPrice * shares - fee) : (unitPrice * shares + fee);
-        const updatedValue = selectedAsset.value - oldDeltaValue + newDeltaValue;
-
-        const updatedHistory = [...selectedAsset.history];
-        updatedHistory[editingRecord.index] = {
-          date: editingRecord.date,
-          type: editingRecord.type,
-          unitPrice,
-          shares,
-          fee,
-          amount
         };
 
-        const updatedAssets = assets.map(a => a.id === selectedAsset.id ? {...a, history: sortHistoryByDate(updatedHistory), value: updatedValue} : a);
-        setAssets(updatedAssets);
-        setSelectedAsset({...selectedAsset, history: sortHistoryByDate(updatedHistory), value: updatedValue});
-        setEditingRecord(null);
-      };
+        const handleAddTransaction = () => {
+          if (
+            !newTransaction.name ||
+            !newTransaction.unitPrice ||
+            !newTransaction.shares
+          )
+            return;
 
-      const cancelEdit = () => {
-        setEditingRecord(null);
-      };
+          const unitPrice = parseFloat(newTransaction.unitPrice);
+          const shares = parseInt(newTransaction.shares);
+          const fee = parseInt(newTransaction.fee);
+          const { amount } = calculateFeeAndAmount(
+            unitPrice,
+            shares,
+            newTransaction.transactionType,
+            newTransaction.type,
+            fee,
+          );
+          const transaction = {
+            date: newTransaction.date,
+            type: newTransaction.transactionType,
+            unitPrice,
+            shares,
+            fee,
+            amount,
+          };
 
-      const handleAssetClick = (asset) => {
-        setSelectedAsset(asset);
-        setShowRecords(false);
-        setEditingRecord(null);
-      };
+          let updatedAssets = [...assets];
+          let assetIndex = updatedAssets.findIndex(
+            (a) => a.name === newTransaction.name,
+          );
 
-      const closeModal = () => {
-        setSelectedAsset(null);
-        setShowRecords(false);
-        setEditingRecord(null);
-      };
+          if (assetIndex === -1) {
+            updatedAssets.push({
+              id: assets.length + 1,
+              name: newTransaction.name,
+              type: newTransaction.type,
+              history: [transaction],
+            });
+          } else {
+            updatedAssets[assetIndex].history.push(transaction);
+            updatedAssets[assetIndex].history = sortHistoryByDate(
+              updatedAssets[assetIndex].history,
+            );
+          }
 
-      const toggleRecords = () => {
-        setShowRecords(!showRecords);
-        setEditingRecord(null);
-      };
+          setAssets(updatedAssets);
+          setSelectedAsset(null);
+          setShowRecords(false);
+          setShowTransactionForm(false);
+          setNewTransaction({
+            name: "",
+            type: "ETF",
+            transactionType: "買進",
+            date: "2025-08-08",
+            unitPrice: "",
+            shares: "",
+            fee: 0,
+            amount: 0,
+          });
+        };
 
-      const exportAssetsCSV = () => {
-        const csvContent = "名稱,類型,張數,目前市值,持有成本,每股買進均價(含息),每股買進均價(不含息),累計配息\n" +
-          assets.map(asset => {
-            const lots = calculateLots(asset.history);
-            const marketValue = calculateCurrentMarketValue(asset.history, asset.name);
-            const holdingCost = calculateHoldingCost(asset.history);
-            const average = calculateAverageBuyPrice(asset.history);
-            const dividend = calculateTotalDividend(asset.history);
-            return `${asset.name},${asset.type},${lots},${marketValue},${holdingCost},${average.withDividend},${average.withoutDividend},${dividend}`;
-          }).join('\n');
-        downloadCSV(csvContent, '資產清單.csv');
-      };
+        const deleteRecord = (index) => {
+          const updatedHistory = [...selectedAsset.history];
+          updatedHistory.splice(index, 1);
+          const updatedAssets = assets.map((a) =>
+            a.id === selectedAsset.id
+              ? { ...a, history: sortHistoryByDate(updatedHistory) }
+              : a,
+          );
+          setAssets(updatedAssets);
+          setSelectedAsset({
+            ...selectedAsset,
+            history: sortHistoryByDate(updatedHistory),
+          });
+        };
 
-      const exportAssetRecordsCSV = () => {
-        const csvContent = "編號,交易日期,類型,單價,股數,手續費,交易金額\n" +
-          selectedAsset.history.map((record, index) => {
-            return `${index + 1},${record.date},${record.type},${record.unitPrice},${record.shares},${record.fee},${record.amount}`;
-          }).join('\n');
-        downloadCSV(csvContent, `${selectedAsset.name}_交易紀錄.csv`);
-      };
+        const startEditingRecord = (index) => {
+          const record = selectedAsset.history[index];
+          setEditingRecord({ index, ...record });
+        };
 
-      const downloadCSV = (content, filename) => {
-        const blob = new Blob(["\uFEFF" + content], { type: 'text/csv;charset=utf-8;' });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = filename;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      };
+        const handleEditChange = (e) => {
+          const { name, value } = e.target;
+          setEditingRecord((prev) => {
+            const updated = { ...prev, [name]: value };
+            if (name === "unitPrice" || name === "shares" || name === "fee") {
+              const unitPriceVal = parseFloat(updated.unitPrice || 0);
+              const sharesVal = parseInt(updated.shares || 0);
+              const feeVal = parseInt(updated.fee || 0);
+              const { amount } = calculateFeeAndAmount(
+                unitPriceVal,
+                sharesVal,
+                updated.type,
+                selectedAsset.type,
+                feeVal,
+              );
+              updated.amount = amount;
+            }
+            return updated;
+          });
+        };
 
-      return (
-        <div className="max-w-4xl mx-auto p-2 sm:p-4">
-          {selectedAsset ? (
-            <div className="miyazaki-card p-4 sm:p-6">
-              <button
-                onClick={closeModal}
-                className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded mb-4"
-              >
-                返回主頁
-              </button>
-              <h2 className="text-xl sm:text-2xl font-bold mb-4">{getFormalName(selectedAsset.name)}</h2>
-              <div className="space-y-3 sm:space-y-4">
-                <p><strong>類型：</strong>{selectedAsset.type}</p>
-                <p><strong>張數：</strong>{calculateLots(selectedAsset.history).toLocaleString()}</p>
-                <p><strong>持有股數：</strong>{calculateHeldShares(selectedAsset.history, '2025-08-08').toLocaleString()}</p>
-                <p><strong>目前市值：</strong>NT${calculateCurrentMarketValue(selectedAsset.history, selectedAsset.name).toLocaleString()}</p>
-                <p><strong>持有成本：</strong>NT${calculateHoldingCost(selectedAsset.history).toLocaleString()}</p>
-                <p><strong>買進價格（含息）：</strong>NT${calculateBuyPrice(selectedAsset.history).withDividend.toLocaleString()}</p>
-                <p><strong>買進價格（不含息）：</strong>NT${calculateBuyPrice(selectedAsset.history).withoutDividend.toLocaleString()}</p>
-                <p><strong>每股買進均價（含息）：</strong>{calculateAverageBuyPrice(selectedAsset.history).withDividend} NT$</p>
-                <p><strong>每股買進均價（不含息）：</strong>{calculateAverageBuyPrice(selectedAsset.history).withoutDividend} NT$</p>
-                <p><strong>累計配息：</strong>{calculateTotalDividend(selectedAsset.history).toLocaleString()} NT$</p>
+        const saveEditRecord = () => {
+          if (
+            !editingRecord.date ||
+            !editingRecord.unitPrice ||
+            !editingRecord.shares
+          )
+            return;
+
+          const unitPrice = parseFloat(editingRecord.unitPrice);
+          const shares = parseInt(editingRecord.shares);
+          const fee = parseInt(editingRecord.fee);
+          const { amount } = calculateFeeAndAmount(
+            unitPrice,
+            shares,
+            editingRecord.type,
+            selectedAsset.type,
+            fee,
+          );
+
+          const updatedHistory = [...selectedAsset.history];
+          updatedHistory[editingRecord.index] = {
+            date: editingRecord.date,
+            type: editingRecord.type,
+            unitPrice,
+            shares,
+            fee,
+            amount,
+          };
+
+          const updatedAssets = assets.map((a) =>
+            a.id === selectedAsset.id
+              ? { ...a, history: sortHistoryByDate(updatedHistory) }
+              : a,
+          );
+          setAssets(updatedAssets);
+          setSelectedAsset({
+            ...selectedAsset,
+            history: sortHistoryByDate(updatedHistory),
+          });
+          setEditingRecord(null);
+        };
+
+        const cancelEdit = () => {
+          setEditingRecord(null);
+        };
+
+        const handleAssetClick = (asset) => {
+          setSelectedAsset(asset);
+          setShowRecords(false);
+          setEditingRecord(null);
+          setShowTransactionForm(false);
+          setNewTransaction({
+            name: asset.name,
+            type: asset.type,
+            transactionType: asset.type === "現金" ? "存入" : "買進",
+            date: "2025-08-08",
+            unitPrice: "",
+            shares: asset.type === "現金" ? "1" : "",
+            fee: asset.type === "現金" ? 0 : 0,
+            amount: 0,
+          });
+        };
+
+        const closeModal = () => {
+          setSelectedAsset(null);
+          setShowRecords(false);
+          setEditingRecord(null);
+          setShowTransactionForm(false);
+          setNewTransaction({
+            name: "",
+            type: "ETF",
+            transactionType: "買進",
+            date: "2025-08-08",
+            unitPrice: "",
+            shares: "",
+            fee: 0,
+            amount: 0,
+          });
+        };
+
+        const toggleRecords = () => {
+          setShowRecords(!showRecords);
+          setEditingRecord(null);
+        };
+
+        const exportAssetsCSV = () => {
+          const csvContent =
+            "名稱,類型,股數,持有成本,均價(含息),均價(不含息),累計配息,年化報酬率\n" +
+            assets
+              .map((asset) => {
+                const shares = calculateHeldShares(asset.history, "2025-08-08");
+                const holdingCost = calculateHoldingCost(asset.history);
+                const average = calculateAverageBuyPrice(asset.history);
+                const dividend = calculateTotalDividend(asset.history);
+                const annual = calculateAnnualizedReturn(asset.history);
+                return `${asset.name},${asset.type},${shares},${holdingCost},${average.withDividend},${average.withoutDividend},${dividend},${annual}`;
+              })
+              .join("\n");
+          downloadCSV(csvContent, "資產清單.csv");
+        };
+
+        const exportAssetRecordsCSV = () => {
+          const csvContent =
+            "編號,交易日期,類型,單價,股數,手續費,交易金額\n" +
+            selectedAsset.history
+              .map((record, index) => {
+                return `${index + 1},${record.date},${record.type},${record.unitPrice},${record.shares},${record.fee},${record.amount}`;
+              })
+              .join("\n");
+          downloadCSV(csvContent, `${selectedAsset.name}_交易紀錄.csv`);
+        };
+
+        const downloadCSV = (content, filename) => {
+          const blob = new Blob(["\uFEFF" + content], {
+            type: "text/csv;charset=utf-8;",
+          });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.download = filename;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        };
+
+        return (
+          <div className="max-w-4xl mx-auto p-2 sm:p-4">
+            {selectedAsset ? (
+              <div className="miyazaki-card p-4 sm:p-6">
                 <button
-                  onClick={toggleRecords}
-                  className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded"
+                  onClick={closeModal}
+                  className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded mb-4"
                 >
-                  {showRecords ? '隱藏交易紀錄' : '顯示交易紀錄'}
+                  返回主頁
                 </button>
-                <button
-                  onClick={exportAssetRecordsCSV}
-                  className="export-button"
-                >
-                  匯出交易紀錄CSV
-                </button>
-                {showRecords && !editingRecord && (
-                  <div className="overflow-x-auto mt-4">
-                    <table className="w-full text-left border-collapse">
-                      <thead>
-                        <tr className="miyazaki-table-header">
-                          <th className="p-2 sm:p-2 border">編號</th>
-                          <th className="p-2 sm:p-2 border">交易日期</th>
-                          <th className="p-2 sm:p-2 border">類型</th>
-                          <th className="p-2 sm:p-2 border">單價 (NT$)</th>
-                          <th className="p-2 sm:p-2 border">股數</th>
-                          <th className="p-2 sm:p-2 border">手續費 (NT$)</th>
-                          <th className="p-2 sm:p-2 border">交易金額 (NT$)</th>
-                          <th className="p-2 sm:p-2 border">操作</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {selectedAsset.history.map((record, index) => (
-                          <tr key={index} className="border-b">
-                            <td className="p-2 sm:p-2">{index + 1}</td>
-                            <td className="p-2 sm:p-2">{record.date}</td>
-                            <td className="p-2 sm:p-2">{record.type}</td>
-                            <td className="p-2 sm:p-2">{record.unitPrice.toLocaleString()}</td>
-                            <td className="p-2 sm:p-2">{record.shares.toLocaleString()}</td>
-                            <td className="p-2 sm:p-2">{record.fee.toLocaleString()}</td>
-                            <td className="p-2 sm:p-2">{record.amount.toLocaleString()}</td>
-                            <td className="p-2 sm:p-2">
-                              <button
-                                onClick={() => startEditingRecord(index)}
-                                className="edit-button"
-                              >
-                                修改
-                              </button>
-                              <button
-                                onClick={() => deleteRecord(index)}
-                                className="delete-button"
-                              >
-                                刪除
-                              </button>
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-                {editingRecord && (
-                  <div className="mt-4">
-                    <h3 className="text-base sm:text-lg font-semibold mb-2">修改交易紀錄</h3>
-                    <div className="space-y-3 sm:space-y-4">
-                      <input
-                        type="date"
-                        name="date"
-                        value={editingRecord.date}
-                        onChange={handleEditChange}
-                        className="w-full p-2 border rounded text-sm sm:text-base"
-                      />
-                      <select
-                        name="type"
-                        value={editingRecord.type}
-                        onChange={handleEditChange}
-                        className="w-full p-2 border rounded text-sm sm:text-base"
-                        disabled={selectedAsset.type === '現金'}
-                      >
-                        <option value="買進">買進</option>
-                        <option value="賣出">賣出</option>
-                        <option value="除息">除息</option>
-                      </select>
-                      {selectedAsset.type === '現金' && (
-                        <select
-                          name="type"
-                          value={editingRecord.type}
-                          onChange={handleEditChange}
-                          className="w-full p-2 border rounded text-sm sm:text-base"
-                        >
-                          <option value="存入">存入</option>
-                          <option value="提取">提取</option>
-                        </select>
-                      )}
-                      <input
-                        type="number"
-                        name="unitPrice"
-                        placeholder={selectedAsset.type === '現金' ? '金額 (NT$)' : (editingRecord.type === '除息' ? '每股除息價格 (NT$)' : '單價 (NT$)')}
-                        value={editingRecord.unitPrice}
-                        onChange={handleEditChange}
-                        className="w-full p-2 border rounded text-sm sm:text-base"
-                      />
-                      <input
-                        type="number"
-                        name="shares"
-                        placeholder={editingRecord.type === '除息' ? '持有股數 (自動計算)' : '股數 (1張=1000股)'}
-                        value={editingRecord.shares}
-                        onChange={handleEditChange}
-                        className="w-full p-2 border rounded text-sm sm:text-base"
-                        disabled={editingRecord.type === '除息' || selectedAsset.type === '現金'}
-                      />
-                      <input
-                        type="number"
-                        name="fee"
-                        placeholder="手續費 (NT$，可修改)"
-                        value={editingRecord.fee}
-                        onChange={handleEditChange}
-                        className="w-full p-2 border rounded text-sm sm:text-base"
-                      />
-                      <div className="text-sm text-gray-600">
-                        交易金額：NT${editingRecord.amount.toLocaleString()} (自動計算)
-                      </div>
-                      <div className="flex space-x-2">
-                        <button
-                          onClick={saveEditRecord}
-                          className="miyazaki-button w-full p-2 rounded text-sm sm:text-base"
-                        >
-                          儲存
-                        </button>
-                        <button
-                          onClick={cancelEdit}
-                          className="delete-button w-full p-2 rounded text-sm sm:text-base"
-                        >
-                          取消
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : (
-            <>
-              <header className="miyazaki-header p-4 sm:p-6 rounded-lg mb-4 sm:mb-6">
-                <h1 className="text-xl sm:text-2xl font-bold">個人資產儀表板</h1>
-                <p className="text-base sm:text-lg mt-2">總資產：NT${Math.round(totalValue).toLocaleString()}</p>
-              </header>
-              <main className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
-                <div className="miyazaki-card p-4 sm:p-6">
-                  <h2 className="text-lg sm:text-xl font-semibold mb-4">資產清單</h2>
+                <h2 className="text-xl sm:text-2xl font-bold mb-4">
+                  {selectedAsset.name}
+                </h2>
+                <div className="space-y-3 sm:space-y-4">
+                  <p>
+                    <strong>類型：</strong>
+                    {selectedAsset.type}
+                  </p>
+                  <p>
+                    <strong>股數：</strong>
+                    {calculateHeldShares(
+                      selectedAsset.history,
+                      "2025-08-08",
+                    ).toLocaleString()}
+                  </p>
+                  <p>
+                    <strong>持有成本：</strong>NT$
+                    {calculateHoldingCost(
+                      selectedAsset.history,
+                    ).toLocaleString()}
+                  </p>
+                  <p>
+                    <strong>買進價格（含息）：</strong>NT$
+                    {calculateBuyPrice(
+                      selectedAsset.history,
+                    ).withDividend.toLocaleString()}
+                  </p>
+                  <p>
+                    <strong>買進價格（不含息）：</strong>NT$
+                    {calculateBuyPrice(
+                      selectedAsset.history,
+                    ).withoutDividend.toLocaleString()}
+                  </p>
+                  <p>
+                    <strong>每股買進均價（含息）：</strong>
+                    {
+                      calculateAverageBuyPrice(selectedAsset.history)
+                        .withDividend
+                    }{" "}
+                    NT$
+                  </p>
+                  <p>
+                    <strong>每股買進均價（不含息）：</strong>
+                    {
+                      calculateAverageBuyPrice(selectedAsset.history)
+                        .withoutDividend
+                    }{" "}
+                    NT$
+                  </p>
+                  <p>
+                    <strong>累計配息：</strong>
+                    {calculateTotalDividend(
+                      selectedAsset.history,
+                    ).toLocaleString()}{" "}
+                    NT$
+                  </p>
+                  <p>
+                    <strong>年化報酬率：</strong>
+                    {calculateAnnualizedReturn(selectedAsset.history) === "N/A"
+                      ? "N/A"
+                      : calculateAnnualizedReturn(selectedAsset.history) +
+                        "%"}{" "}
+                  </p>
                   <button
-                    onClick={exportAssetsCSV}
-                    className="export-button mb-4"
+                    onClick={() => setShowTransactionForm(!showTransactionForm)}
+                    className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded"
                   >
-                    匯出資產清單CSV
-                  </button>
-                  {assets.length === 0 ? (
-                    <p className="text-gray-500">尚未有資產，請新增交易。</p>
-                  ) : (
-                    <ul className="space-y-2">
-                      {assets.map(asset => (
-                        <li 
-                          key={asset.id} 
-                          className="border-b py-2"
-                        >
-                          <div 
-                            className="toggle-button"
-                            onClick={() => toggleAssetDetails(asset.id)}
-                          >
-                            <span className="asset-name">{asset.name} ({asset.type})</span>
-                            <span>{Math.round(asset.value)}</span>
-                          </div>
-                          {expandedAssets[asset.id] && (
-                            <div className="asset-info text-sm text-gray-600 mt-1">
-                              <p className="asset-detail">張數：{calculateLots(asset.history).toLocaleString()}</p>
-                              <p className="asset-detail">目前市值：{calculateCurrentMarketValue(asset.history, asset.name).toLocaleString()}</p>
-                              <p className="asset-detail">持有成本：{calculateHoldingCost(asset.history).toLocaleString()}</p>
-                              <p className="asset-detail">均價（含息）：{calculateAverageBuyPrice(asset.history).withDividend}</p>
-                              <p className="asset-detail">均價（不含息）：{calculateAverageBuyPrice(asset.history).withoutDividend}</p>
-                              <p className="asset-detail">累計配息：{calculateTotalDividend(asset.history).toLocaleString()}</p>
-                              <button
-                                onClick={() => handleAssetClick(asset)}
-                                className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded mt-2"
-                              >
-                                查看詳情
-                              </button>
-                            </div>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-                <div className="miyazaki-card p-4 sm:p-6">
-                  <h2 className="text-lg sm:text-xl font-semibold mb-4">新增交易</h2>
-                  <button
-                    onClick={toggleTransactionForm}
-                    className="miyazaki-button w-full p-2 rounded text-sm sm:text-base mb-4"
-                  >
-                    {showTransactionForm ? '隱藏新增交易' : '顯示新增交易'}
+                    {showTransactionForm ? "隱藏新增交易" : "新增交易"}
                   </button>
                   {showTransactionForm && (
-                    <div className="space-y-3 sm:space-y-4">
-                      <div className="relative">
-                        <input
-                          list="assetNames"
-                          name="name"
-                          placeholder="資產名稱 (選取或自訂輸入)"
-                          value={newTransaction.name}
-                          onChange={handleInputChange}
-                          className="w-full p-2 border rounded text-sm sm:text-base"
-                        />
-                        <datalist id="assetNames">
-                          {assets.map(asset => (
-                            <option key={asset.id} value={asset.name} />
-                          ))}
-                        </datalist>
-                      </div>
-                      <select
-                        name="type"
-                        value={newTransaction.type}
-                        onChange={handleInputChange}
-                        className="w-full p-2 border rounded text-sm sm:text-base"
-                      >
-                        <option value="ETF">ETF</option>
-                        <option value="股票">股票</option>
-                        <option value="現金">現金</option>
-                      </select>
+                    <div className="space-y-3 sm:space-y-4 mt-2">
                       <input
                         type="date"
                         name="date"
@@ -797,7 +737,7 @@
                         onChange={handleInputChange}
                         className="w-full p-2 border rounded text-sm sm:text-base"
                       />
-                      {newTransaction.type !== '現金' ? (
+                      {selectedAsset.type !== "現金" ? (
                         <select
                           name="transactionType"
                           value={newTransaction.transactionType}
@@ -822,7 +762,13 @@
                       <input
                         type="number"
                         name="unitPrice"
-                        placeholder={newTransaction.type === '現金' ? '金額 (NT$)' : (newTransaction.transactionType === '除息' ? '每股除息價格 (NT$)' : '單價 (NT$)')}
+                        placeholder={
+                          selectedAsset.type === "現金"
+                            ? "金額 (NT$)"
+                            : newTransaction.transactionType === "除息"
+                              ? "每股除息價格 (NT$)"
+                              : "單價 (NT$)"
+                        }
                         value={newTransaction.unitPrice}
                         onChange={handleInputChange}
                         className="w-full p-2 border rounded text-sm sm:text-base"
@@ -830,11 +776,18 @@
                       <input
                         type="number"
                         name="shares"
-                        placeholder={newTransaction.transactionType === '除息' ? '持有股數 (自動計算)' : '股數 (1張=1000股)'}
+                        placeholder={
+                          newTransaction.transactionType === "除息"
+                            ? "持有股數 (自動計算)"
+                            : "股數"
+                        }
                         value={newTransaction.shares}
                         onChange={handleInputChange}
                         className="w-full p-2 border rounded text-sm sm:text-base"
-                        disabled={newTransaction.transactionType === '除息' || newTransaction.type === '現金'}
+                        disabled={
+                          newTransaction.transactionType === "除息" ||
+                          selectedAsset.type === "現金"
+                        }
                       />
                       <input
                         type="number"
@@ -845,7 +798,8 @@
                         className="w-full p-2 border rounded text-sm sm:text-base"
                       />
                       <div className="text-sm text-gray-600">
-                        交易金額：NT${newTransaction.amount.toLocaleString()} (自動計算)
+                        交易金額：NT${newTransaction.amount.toLocaleString()}{" "}
+                        (自動計算)
                       </div>
                       <button
                         onClick={handleAddTransaction}
@@ -855,29 +809,417 @@
                       </button>
                     </div>
                   )}
-                </div>
-                <div className="miyazaki-card p-4 sm:p-6 md:col-span-2">
-                  <h2 className="text-lg sm:text-xl font-semibold mb-4">資產分配</h2>
                   <button
-                    onClick={togglePieChart}
-                    className="miyazaki-button w-full p-2 rounded text-sm sm:text-base mb-4"
+                    onClick={toggleRecords}
+                    className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded mt-2"
                   >
-                    {showPieChart ? '隱藏資產分配' : '顯示資產分配'}
+                    {showRecords ? "隱藏交易紀錄" : "顯示交易紀錄"}
                   </button>
-                  {showPieChart && (
-                    <div className="h-48 sm:h-64">
-                      <canvas id="assetChart"></canvas>
+                  <button
+                    onClick={exportAssetRecordsCSV}
+                    className="export-button"
+                  >
+                    匯出交易紀錄CSV
+                  </button>
+                  {showRecords && !editingRecord && (
+                    <div className="overflow-x-auto mt-4">
+                      <table className="w-full text-left border-collapse">
+                        <thead>
+                          <tr className="miyazaki-table-header">
+                            <th className="p-2 sm:p-2 border">編號</th>
+                            <th className="p-2 sm:p-2 border">交易日期</th>
+                            <th className="p-2 sm:p-2 border">類型</th>
+                            <th className="p-2 sm:p-2 border">單價 (NT$)</th>
+                            <th className="p-2 sm:p-2 border">股數</th>
+                            <th className="p-2 sm:p-2 border">手續費 (NT$)</th>
+                            <th className="p-2 sm:p-2 border">
+                              交易金額 (NT$)
+                            </th>
+                            <th className="p-2 sm:p-2 border">操作</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {selectedAsset.history.map((record, index) => (
+                            <tr key={index} className="border-b">
+                              <td className="p-2 sm:p-2">{index + 1}</td>
+                              <td className="p-2 sm:p-2">{record.date}</td>
+                              <td className="p-2 sm:p-2">{record.type}</td>
+                              <td className="p-2 sm:p-2">
+                                {record.unitPrice.toLocaleString()}
+                              </td>
+                              <td className="p-2 sm:p-2">
+                                {record.shares.toLocaleString()}
+                              </td>
+                              <td className="p-2 sm:p-2">
+                                {record.fee.toLocaleString()}
+                              </td>
+                              <td className="p-2 sm:p-2">
+                                {record.amount.toLocaleString()}
+                              </td>
+                              <td className="p-2 sm:p-2">
+                                <button
+                                  onClick={() => startEditingRecord(index)}
+                                  className="edit-button"
+                                >
+                                  修改
+                                </button>
+                                <button
+                                  onClick={() => deleteRecord(index)}
+                                  className="delete-button"
+                                >
+                                  刪除
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                  {editingRecord && (
+                    <div className="mt-4">
+                      <h3 className="text-base sm:text-lg font-semibold mb-2">
+                        修改交易紀錄
+                      </h3>
+                      <div className="space-y-3 sm:space-y-4">
+                        <input
+                          type="date"
+                          name="date"
+                          value={editingRecord.date}
+                          onChange={handleEditChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        />
+                        <select
+                          name="type"
+                          value={editingRecord.type}
+                          onChange={handleEditChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                          disabled={selectedAsset.type === "現金"}
+                        >
+                          <option value="買進">買進</option>
+                          <option value="賣出">賣出</option>
+                          <option value="除息">除息</option>
+                        </select>
+                        {selectedAsset.type === "現金" && (
+                          <select
+                            name="type"
+                            value={editingRecord.type}
+                            onChange={handleEditChange}
+                            className="w-full p-2 border rounded text-sm sm:text-base"
+                          >
+                            <option value="存入">存入</option>
+                            <option value="提取">提取</option>
+                          </select>
+                        )}
+                        <input
+                          type="number"
+                          name="unitPrice"
+                          placeholder={
+                            selectedAsset.type === "現金"
+                              ? "金額 (NT$)"
+                              : editingRecord.type === "除息"
+                                ? "每股除息價格 (NT$)"
+                                : "單價 (NT$)"
+                          }
+                          value={editingRecord.unitPrice}
+                          onChange={handleEditChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        />
+                        <input
+                          type="number"
+                          name="shares"
+                          placeholder={
+                            editingRecord.type === "除息"
+                              ? "持有股數 (自動計算)"
+                              : "股數"
+                          }
+                          value={editingRecord.shares}
+                          onChange={handleEditChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                          disabled={
+                            editingRecord.type === "除息" ||
+                            selectedAsset.type === "現金"
+                          }
+                        />
+                        <input
+                          type="number"
+                          name="fee"
+                          placeholder="手續費 (NT$，可修改)"
+                          value={editingRecord.fee}
+                          onChange={handleEditChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        />
+                        <div className="text-sm text-gray-600">
+                          交易金額：NT${editingRecord.amount.toLocaleString()}{" "}
+                          (自動計算)
+                        </div>
+                        <div className="flex space-x-2">
+                          <button
+                            onClick={saveEditRecord}
+                            className="miyazaki-button w-full p-2 rounded text-sm sm:text-base"
+                          >
+                            儲存
+                          </button>
+                          <button
+                            onClick={cancelEdit}
+                            className="delete-button w-full p-2 rounded text-sm sm:text-base"
+                          >
+                            取消
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   )}
                 </div>
-              </main>
-            </>
-          )}
-        </div>
-      );
-    };
+              </div>
+            ) : (
+              <>
+                <header className="miyazaki-header p-4 sm:p-6 rounded-lg mb-4 sm:mb-6">
+                  <h1 className="text-xl sm:text-2xl font-bold">
+                    個人資產儀表板
+                  </h1>
+                  <p className="text-base sm:text-lg mt-2">
+                    總資產持有成本：{Math.round(totalValue).toLocaleString()}
+                  </p>
+                  <p className="text-base sm:text-lg mt-1">
+                    總資產年化報酬率：
+                    {overallAnnualizedReturn() === "N/A"
+                      ? "N/A"
+                      : overallAnnualizedReturn() + "%"}{" "}
+                  </p>
+                </header>
+                <main className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
+                  <div className="miyazaki-card p-4 sm:p-6">
+                    <h2 className="text-lg sm:text-xl font-semibold mb-4">
+                      資產清單
+                    </h2>
+                    <button
+                      onClick={exportAssetsCSV}
+                      className="export-button mb-4"
+                    >
+                      匯出資產清單CSV
+                    </button>
+                    {assets.length === 0 ? (
+                      <p className="text-gray-500">尚未有資產，請新增交易。</p>
+                    ) : (
+                      <ul className="space-y-2">
+                        {assets.map((asset) => (
+                          <li key={asset.id} className="border-b py-2">
+                            <div
+                              className="toggle-button"
+                              onClick={() => toggleAssetDetails(asset.id)}
+                            >
+                              <span className="asset-name">
+                                {asset.name} ({asset.type})
+                              </span>
+                              <span>
+                                {Math.round(
+                                  calculateHoldingCost(asset.history),
+                                )}
+                              </span>
+                            </div>
+                            {expandedAssets[asset.id] && (
+                              <div className="asset-info text-sm text-gray-600 mt-1">
+                                <p className="asset-detail">
+                                  股數：
+                                  {calculateHeldShares(
+                                    asset.history,
+                                    "2025-08-08",
+                                  ).toLocaleString()}
+                                </p>
+                                <p className="asset-detail">
+                                  持有成本：
+                                  {calculateHoldingCost(
+                                    asset.history,
+                                  ).toLocaleString()}
+                                </p>
+                                <p className="asset-detail">
+                                  均價（含息）：
+                                  {
+                                    calculateAverageBuyPrice(asset.history)
+                                      .withDividend
+                                  }
+                                </p>
+                                <p className="asset-detail">
+                                  均價（不含息）：
+                                  {
+                                    calculateAverageBuyPrice(asset.history)
+                                      .withoutDividend
+                                  }
+                                </p>
+                                <p className="asset-detail">
+                                  累計配息：
+                                  {calculateTotalDividend(
+                                    asset.history,
+                                  ).toLocaleString()}
+                                </p>
+                                <p className="asset-detail">
+                                  年化報酬率：
+                                  {calculateAnnualizedReturn(asset.history) ===
+                                  "N/A"
+                                    ? "N/A"
+                                    : calculateAnnualizedReturn(asset.history) +
+                                      "%"}
+                                </p>
+                                <button
+                                  onClick={() => handleAssetClick(asset)}
+                                  className="miyazaki-button px-3 py-1 sm:px-4 sm:py-2 rounded mt-2"
+                                >
+                                  查看詳情
+                                </button>
+                              </div>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  <div className="miyazaki-card p-4 sm:p-6">
+                    <h2 className="text-lg sm:text-xl font-semibold mb-4">
+                      新增資產
+                    </h2>
+                    <button
+                      onClick={toggleTransactionForm}
+                      className="miyazaki-button w-full p-2 rounded text-sm sm:text-base mb-4"
+                    >
+                      {showTransactionForm ? "隱藏新增資產" : "新增資產"}
+                    </button>
+                    {showTransactionForm && (
+                      <div className="space-y-3 sm:space-y-4">
+                        <div className="relative">
+                          <input
+                            list="assetNames"
+                            name="name"
+                            placeholder="資產名稱 (選取或自訂輸入)"
+                            value={newTransaction.name}
+                            onChange={handleInputChange}
+                            className="w-full p-2 border rounded text-sm sm:text-base"
+                          />
+                          <datalist id="assetNames">
+                            {assets.map((asset) => (
+                              <option key={asset.id} value={asset.name} />
+                            ))}
+                          </datalist>
+                        </div>
+                        <select
+                          name="type"
+                          value={newTransaction.type}
+                          onChange={handleInputChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        >
+                          <option value="ETF">ETF</option>
+                          <option value="股票">股票</option>
+                          <option value="現金">現金</option>
+                        </select>
+                        <input
+                          type="date"
+                          name="date"
+                          value={newTransaction.date}
+                          onChange={handleInputChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        />
+                        {newTransaction.type !== "現金" ? (
+                          <select
+                            name="transactionType"
+                            value={newTransaction.transactionType}
+                            onChange={handleInputChange}
+                            className="w-full p-2 border rounded text-sm sm:text-base"
+                          >
+                            <option value="買進">買進</option>
+                            <option value="賣出">賣出</option>
+                            <option value="除息">除息</option>
+                          </select>
+                        ) : (
+                          <select
+                            name="transactionType"
+                            value={newTransaction.transactionType}
+                            onChange={handleInputChange}
+                            className="w-full p-2 border rounded text-sm sm:text-base"
+                          >
+                            <option value="存入">存入</option>
+                            <option value="提取">提取</option>
+                          </select>
+                        )}
+                        <input
+                          type="number"
+                          name="unitPrice"
+                          placeholder={
+                            newTransaction.type === "現金"
+                              ? "金額 (NT$)"
+                              : newTransaction.transactionType === "除息"
+                                ? "每股除息價格 (NT$)"
+                                : "單價 (NT$)"
+                          }
+                          value={newTransaction.unitPrice}
+                          onChange={handleInputChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        />
+                        <input
+                          type="number"
+                          name="shares"
+                          placeholder={
+                            newTransaction.transactionType === "除息"
+                              ? "持有股數 (自動計算)"
+                              : "股數"
+                          }
+                          value={newTransaction.shares}
+                          onChange={handleInputChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                          disabled={
+                            newTransaction.transactionType === "除息" ||
+                            newTransaction.type === "現金"
+                          }
+                        />
+                        <input
+                          type="number"
+                          name="fee"
+                          placeholder="手續費 (NT$，可修改)"
+                          value={newTransaction.fee}
+                          onChange={handleInputChange}
+                          className="w-full p-2 border rounded text-sm sm:text-base"
+                        />
+                        <div className="text-sm text-gray-600">
+                          交易金額：NT${newTransaction.amount.toLocaleString()}{" "}
+                          (自動計算)
+                        </div>
+                        <button
+                          onClick={handleAddTransaction}
+                          className="miyazaki-button w-full p-2 rounded text-sm sm:text-base"
+                        >
+                          新增交易
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="miyazaki-card p-4 sm:p-6 md:col-span-2">
+                    <h2 className="text-lg sm:text-xl font-semibold mb-4">
+                      資產分配
+                    </h2>
+                    <button
+                      onClick={togglePieChart}
+                      className="miyazaki-button w-full p-2 rounded text-sm sm:text-base mb-4"
+                    >
+                      {showPieChart ? "隱藏資產分配" : "顯示資產分配"}
+                    </button>
+                    {showPieChart &&
+                      (totalValue === 0 ? (
+                        <p className="text-center text-gray-500">
+                          無數據可顯示
+                        </p>
+                      ) : (
+                        <div className="h-48 sm:h-64">
+                          <canvas id="assetChart"></canvas>
+                        </div>
+                      ))}
+                  </div>
+                </main>
+              </>
+            )}
+          </div>
+        );
+      };
 
-    ReactDOM.render(<AssetDashboard />, document.getElementById('root'));
-  </script>
-</body>
+      ReactDOM.render(<AssetDashboard />, document.getElementById("root"));
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- build single-page React asset dashboard storing data in localStorage
- show detailed asset metrics and annualized returns with exportable CSV reports
- add responsive Miyazaki-themed UI and allocation pie chart

## Testing
- `npx prettier --write index.html`

------
https://chatgpt.com/codex/tasks/task_e_6896022f273c8320b94a864a83cfa74b